### PR TITLE
Upgrade cpython

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ quick-error = "1.2"
 serde_json = "1.0"
 
 [dependencies.cpython]
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpython-json"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Iliana Weller <ilianaw@buttslol.net>"]
 description = "Converts native Python objects into serde_json Values and back again"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Add `cpython-json` to your `Cargo.toml` alongside `cpython`:
 ```toml
 [dependencies]
 cpython = "*"
-cpython-json = "0.1"
+cpython-json = "0.3"
 ```
 
 Similar to `cpython`, Python 3 is used by default. To use Python 2:
 
 ```toml
 [dependencies.cpython-json]
-version = "0.1"
+version = "0.3"
 default-features = false
 features = ["python27-sys"]
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,14 @@
 //! ```toml
 //! [dependencies]
 //! cpython = "*"
-//! cpython-json = "0.1"
+//! cpython-json = "0.3"
 //! ```
 //!
 //! Similar to `cpython`, Python 3 is used by default. To use Python 2:
 //!
 //! ```toml
 //! [dependencies.cpython-json]
-//! version = "0.1"
+//! version = "0.3"
 //! default-features = false
 //! features = ["python27-sys"]
 //! ```


### PR DESCRIPTION
This change updates the cpython dependency to 0.2. There are various changes in the 0.2 cpython release that make it easier to specify the python interpreter at build time. See:
- https://github.com/dgrunwald/rust-cpython/commit/61ab92e977b215504178cffaeba65bc3384cdb93#diff-fe52cdca0106226d05cf00d7c92c89ee
- https://github.com/dgrunwald/rust-cpython/commit/e7abe40cd1eb6636a7a3cf1ace42ec69acdc0436#diff-fe52cdca0106226d05cf00d7c92c89ee

This change updates the release version to "0.3", so that dependencies can opt into this change.